### PR TITLE
fix: center align logo during search/load

### DIFF
--- a/src/components/basic/LoadingIndicator.tsx
+++ b/src/components/basic/LoadingIndicator.tsx
@@ -32,27 +32,23 @@ const LogoLoadingIndicator = ({ size, message }: { size: 'small' | 'large'; mess
 
   const travelDistance = theme.spacing.s;
   return (
-    <Box
-      flex={1}
-      justifyContent="center"
-      alignItems="center"
-      alignSelf="center"
-      width={containerSize}
-      height={containerSize}>
-      <MotiView
-        from={{ translateY: 0 }}
-        animate={{ translateY: travelDistance }}
-        transition={{
-          type: 'timing',
-          duration: LOADING_LOGO_ANIMATION_DURATION_MS,
-          loop: true,
-          easing: Easing.inOut(Easing.ease),
-        }}
-        style={{ paddingHorizontal: theme.spacing.s }}>
-        <AppLogo size={logoSize} />
-      </MotiView>
+    <Box flex={1} justifyContent="center" alignItems="center" alignSelf="center">
+      <Box width={containerSize} height={containerSize}>
+        <MotiView
+          from={{ translateY: 0 }}
+          animate={{ translateY: travelDistance }}
+          transition={{
+            type: 'timing',
+            duration: LOADING_LOGO_ANIMATION_DURATION_MS,
+            loop: true,
+            easing: Easing.inOut(Easing.ease),
+          }}
+          style={{ paddingHorizontal: theme.spacing.s }}>
+          <AppLogo size={logoSize} />
+        </MotiView>
+      </Box>
       {message && (
-        <Text variant="body" marginTop="m" color="textSecondary">
+        <Text variant="body" marginTop="m" color="textSecondary" textAlign="center">
           {message}
         </Text>
       )}


### PR DESCRIPTION
## Summary

There is an issue reported where the search logo is not centered on search/next episode page, these changes makes the logo center on those areas.

## Motivation

Better UX

## Testing

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] Tested on: Android

## Screenshots / Video (if UI)
<img width="1080" height="2400" alt="Screenshot_1767102061" src="https://github.com/user-attachments/assets/46e0e540-c5a1-44bf-9444-16983683cf14" />
<img width="2400" height="1080" alt="Screenshot_1767102102" src="https://github.com/user-attachments/assets/e21d4edb-c1b3-4237-b382-835806027b7d" />


Closes #43 
