### PR TITLE
Set immersive mode on playback to hide navigation bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react-dom": "19.1.0",
     "react-native": "npm:react-native-tvos@0.81-stable",
     "react-native-gesture-handler": "~2.28.0",
+    "react-native-immersive-mode": "^2.0.2",
     "react-native-reanimated": "~4.1.6",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       react-native-gesture-handler:
         specifier: ~2.28.0
         version: 2.28.0(react-native-tvos@0.81.5-1)(react@19.1.0)
+      react-native-immersive-mode:
+        specifier: ^2.0.2
+        version: 2.0.2(react-native-tvos@0.81.5-1)
       react-native-reanimated:
         specifier: ~4.1.6
         version: 4.1.6(@babel/core@7.28.5)(react-native-tvos@0.81.5-1)(react-native-worklets@0.5.1(@babel/core@7.28.5)(react-native-tvos@0.81.5-1)(react@19.1.0))(react@19.1.0)
@@ -4237,6 +4240,11 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  react-native-immersive-mode@2.0.2:
+    resolution: {integrity: sha512-W4YBpf/seURr6pdt91bKWtlQhwoZYgQN1nllj/y+EkwKs5xbu/IiRxlCs/8ML7dyA8wbOFaXR24AC4HOrvxapw==}
+    peerDependencies:
+      react-native: '>=0.60.5'
 
   react-native-is-edge-to-edge@1.2.1:
     resolution: {integrity: sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==}
@@ -10324,6 +10332,10 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
       react: 19.1.0
+      react-native: react-native-tvos@0.81.5-1(@babel/core@7.28.5)(@types/react@19.1.17)(react-native-tvos@0.81.5-1)(react@19.1.0)
+
+  react-native-immersive-mode@2.0.2(react-native-tvos@0.81.5-1):
+    dependencies:
       react-native: react-native-tvos@0.81.5-1(@babel/core@7.28.5)(@types/react@19.1.17)(react-native-tvos@0.81.5-1)(react@19.1.0)
 
   react-native-is-edge-to-edge@1.2.1(react-native-tvos@0.81.5-1)(react@19.1.0):

--- a/src/app/play.tsx
+++ b/src/app/play.tsx
@@ -1,12 +1,13 @@
 import { VideoPlayer } from '@/components/video/VideoPlayer';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { Box } from '@/theme/theme';
-import { Alert } from 'react-native';
+import { Alert, Platform, StatusBar } from 'react-native';
 import type { ContentType } from '@/types/stremio';
 import { useDebugLogger } from '@/utils/debug';
 import { useMediaNavigation } from '@/hooks/useMediaNavigation';
 import { useTVBackButton } from '@/hooks/useTVBackButton';
+import ImmersiveMode from 'react-native-immersive-mode';
 
 const parseBooleanParam = (value?: string): boolean => {
   if (!value) return false;
@@ -28,6 +29,25 @@ const Play = () => {
 
   const debug = useDebugLogger('Play');
   const shouldReturnToStreams = parseBooleanParam(fromAutoPlay);
+
+  // Enable immersive mode (hide navigation bar) on Android
+  useEffect(() => {
+    // Hide status bar on all platforms
+    StatusBar.setHidden(true);
+
+    if (Platform.OS === 'android') {
+      ImmersiveMode.fullLayout(true);
+      ImmersiveMode.setBarMode('FullSticky');
+    }
+
+    return () => {
+      StatusBar.setHidden(false);
+      if (Platform.OS === 'android') {
+        ImmersiveMode.fullLayout(false);
+        ImmersiveMode.setBarMode('Normal');
+      }
+    };
+  }, []);
 
   const returnToStreams = useCallback(() => {
     if (!metaId || !type || !videoId) {

--- a/src/components/video/PlayerControls.tsx
+++ b/src/components/video/PlayerControls.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useState, useEffect, useCallback, useMemo } from 'react';
-import { StyleSheet, Pressable, StatusBar } from 'react-native';
+import { StyleSheet, Pressable } from 'react-native';
 import { Box, Text, Theme } from '@/theme/theme';
 import Slider from '@react-native-community/slider';
 import { useTheme } from '@shopify/restyle';
@@ -138,10 +138,7 @@ export const PlayerControls: FC<PlayerControlsProps> = ({
 
   const textTrackItems = useMemo<PickerItem[]>(() => {
     const preferred = getPreferredLanguageCodes(preferredSubtitleLanguages);
-    return [
-      { label: 'None', value: -1 },
-      ...buildOrderedTrackItems(textTracks, preferred),
-    ];
+    return [{ label: 'None', value: -1 }, ...buildOrderedTrackItems(textTracks, preferred)];
   }, [buildOrderedTrackItems, preferredSubtitleLanguages, textTracks]);
 
   // Auto-hide controls after inactivity
@@ -237,16 +234,13 @@ export const PlayerControls: FC<PlayerControlsProps> = ({
   if (!visible) {
     // Invisible touchable area to show controls
     return (
-      <>
-        <StatusBar hidden />
-        <Pressable
-          testID="player-controls-invisible-area"
-          style={StyleSheet.absoluteFill}
-          onPress={showControls}
-          hasTVPreferredFocus>
-          <Box flex={1} />
-        </Pressable>
-      </>
+      <Pressable
+        testID="player-controls-invisible-area"
+        style={StyleSheet.absoluteFill}
+        onPress={showControls}
+        hasTVPreferredFocus>
+        <Box flex={1} />
+      </Pressable>
     );
   }
 
@@ -255,7 +249,6 @@ export const PlayerControls: FC<PlayerControlsProps> = ({
       testID="player-controls-overlay"
       style={StyleSheet.absoluteFill}
       onPress={toggleControls}>
-      <StatusBar hidden />
       <Box flex={1} justifyContent="space-between">
         {/* Top Bar */}
         <Box


### PR DESCRIPTION
## Summary

Hides the Android navigation bar by using immersive mode.

## Motivation

Navigation bar did not disappear during playback.

## Testing

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] Tested on: Android

Closes #42 
