### PR TITLE
Add MPV player as a VLC alternative (experimental)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 EXPO_NO_TELEMETRY=true
 EXPO_PUBLIC_GITHUB_RELEASES_URL=https://github.com/DodoraApp/DodoStream/releases
+NODE_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,8 @@ web-build/
 expo-env.d.ts
 
 
-ios
-android
+/ios
+/android
 
 # macOS
 .DS_Store

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,3 +1,4 @@
+import 'tsx/cjs';
 import { ExpoConfig, ConfigContext } from 'expo/config';
 const packageJson = require('./package.json');
 
@@ -12,7 +13,6 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     const appName = isDevVariant ? 'DodoStream (Dev)' : 'DodoStream';
     const iosBundleIdentifier = isDevVariant ? 'app.dodora.dodostream.dev' : 'app.dodora.dodostream';
     const androidPackage = isDevVariant ? 'app.dodora.dodostream.dev' : 'app.dodora.dodostream';
-
     return {
         ...config,
         name: appName,
@@ -124,9 +124,6 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         },
         runtimeVersion: {
             policy: 'appVersion',
-        },
-        updates: {
-            url: 'https://u.expo.dev/c7e4f244-2ba8-42dc-a3f6-c197df3d8236',
         },
     };
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,7 @@
 module.exports = {
     preset: 'jest-expo',
     setupFiles: ['./jest.setup.js'],
+    moduleNameMapper: {
+        '^modules/mpv$': '<rootDir>/modules/__mocks__/modules-mpv.ts',
+    },
 };

--- a/modules/__mocks__/modules-mpv.ts
+++ b/modules/__mocks__/modules-mpv.ts
@@ -1,0 +1,19 @@
+/* eslint-env jest */
+import React from 'react';
+import { View } from 'react-native';
+
+const MpvView = React.forwardRef((props, ref) => {
+    React.useImperativeHandle(ref, () => ({
+        seek: jest.fn(),
+        setVolume: jest.fn(),
+        setRate: jest.fn(),
+        setPaused: jest.fn(),
+        setSubtitleTrack: jest.fn(),
+        setAudioTrack: jest.fn(),
+    }));
+    return React.createElement(View, props);
+});
+
+module.exports = {
+    MpvView,
+};

--- a/modules/mpv/android/build.gradle
+++ b/modules/mpv/android/build.gradle
@@ -1,0 +1,48 @@
+apply plugin: 'com.android.library'
+
+group = 'com.dodora.dodostream.mpv'
+version = '0.7.6'
+
+def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
+apply from: expoModulesCorePlugin
+applyKotlinExpoModulesCorePlugin()
+useCoreDependencies()
+useExpoPublishing()
+
+// If you want to use the managed Android SDK versions from expo-modules-core, set this to true.
+// The Android SDK versions will be bumped from time to time in SDK releases and may introduce breaking changes in your module code.
+// Most of the time, you may like to manage the Android SDK versions yourself.
+def useManagedAndroidSdkVersions = false
+if (useManagedAndroidSdkVersions) {
+  useDefaultAndroidSdkVersions()
+} else {
+  buildscript {
+    // Simple helper that allows the root project to override versions declared by this library.
+    ext.safeExtGet = { prop, fallback ->
+      rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+    }
+  }
+  project.android {
+    compileSdkVersion safeExtGet("compileSdkVersion", 36)
+    defaultConfig {
+      minSdkVersion safeExtGet("minSdkVersion", 24)
+      targetSdkVersion safeExtGet("targetSdkVersion", 36)
+    }
+  }
+}
+
+android {
+  namespace "com.dodora.dodostream.mpv"
+  defaultConfig {
+    versionCode 1
+    versionName "0.7.6"
+  }
+  lintOptions {
+    abortOnError false
+  }
+}
+
+dependencies {
+  implementation("dev.jdtech.mpv:libmpv:0.5.1")
+  implementation("androidx.lifecycle:lifecycle-common:2.8.7")
+}

--- a/modules/mpv/android/src/main/AndroidManifest.xml
+++ b/modules/mpv/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest>
+</manifest>

--- a/modules/mpv/android/src/main/java/com/dodora/dodostream/mpv/ExpoMpvView.kt
+++ b/modules/mpv/android/src/main/java/com/dodora/dodostream/mpv/ExpoMpvView.kt
@@ -1,0 +1,606 @@
+ /*
+ * Originally part of: NuvioStreaming - https://github.com/tapframe/NuvioStreaming
+ * Licensed under the GPL-3.0 license.
+ *
+ * Modifications:
+ *  - Adapted for DodoStream by Kombustor, 2026.
+ */
+package com.dodora.dodostream.mpv
+
+import android.content.Context
+import android.graphics.SurfaceTexture
+import android.util.Log
+import android.view.Surface
+import android.view.TextureView
+import dev.jdtech.mpv.MPVLib
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.viewevent.EventDispatcher
+import expo.modules.kotlin.views.ExpoView
+
+class ExpoMpvView(context: Context, appContext: AppContext) : ExpoView(context, appContext), TextureView.SurfaceTextureListener, MPVLib.EventObserver {
+
+    companion object {
+        private const val TAG = "ExpoMpvView"
+    }
+
+    // Event dispatchers for React Native
+    val onLoad by EventDispatcher()
+    val onProgress by EventDispatcher()
+    val onEnd by EventDispatcher()
+    val onError by EventDispatcher()
+    val onBuffering by EventDispatcher()
+    val onTracksChanged by EventDispatcher()
+
+    private val textureView: TextureView
+    private var isMpvInitialized = false
+    private var pendingDataSource: String? = null
+    private var isPaused: Boolean = true
+    private var surface: Surface? = null
+    private var httpHeaders: Map<String, String>? = null
+    
+    // Decoder mode setting: 'auto', 'sw', 'hw', 'hw+' (default: auto)
+    var decoderMode: String = "auto"
+    
+    // GPU mode setting: 'gpu', 'gpu-next' (default: gpu)
+    var gpuMode: String = "gpu"
+    
+    // Flag to track if onLoad has been fired (prevents multiple fires for HLS streams)
+    private var hasLoadEventFired: Boolean = false
+
+    private var resumeOnForeground = false
+    private val lifecycleObserver = object : DefaultLifecycleObserver {
+        override fun onPause(owner: LifecycleOwner) {
+            resumeOnForeground = !isPaused
+            if (resumeOnForeground) {
+                Log.d(TAG, "App backgrounded — pausing MPV")
+                setPaused(true)
+            }
+        }
+        override fun onResume(owner: LifecycleOwner) {
+            if (resumeOnForeground) {
+                setPaused(false)
+                resumeOnForeground = false
+            }
+        }
+        override fun onDestroy(owner: LifecycleOwner) {}
+    }
+
+    init {
+        textureView = TextureView(context).apply {
+            layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+            surfaceTextureListener = this@ExpoMpvView
+            isOpaque = false
+        }
+        addView(textureView)
+        appContext.currentActivity?.let { activity ->
+            (activity as? LifecycleOwner)?.lifecycle?.addObserver(lifecycleObserver)
+        }
+    }
+
+    override fun onSurfaceTextureAvailable(surfaceTexture: SurfaceTexture, width: Int, height: Int) {
+        Log.d(TAG, "Surface texture available: ${width}x${height}")
+        try {
+            surface = Surface(surfaceTexture)
+            
+            MPVLib.create(context.applicationContext)
+            initOptions()
+            MPVLib.init()
+            MPVLib.attachSurface(surface!!)
+            MPVLib.addObserver(this)
+            MPVLib.setPropertyString("android-surface-size", "${width}x${height}")
+            observeProperties()
+            isMpvInitialized = true
+            
+            // If a data source was set before surface was ready, load it now
+            pendingDataSource?.let { url ->
+                loadFile(url)
+                pendingDataSource = null
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to initialize MPV", e)
+            onError(mapOf("error" to "MPV initialization failed: ${e.message}"))
+        }
+    }
+
+    override fun onSurfaceTextureSizeChanged(surfaceTexture: SurfaceTexture, width: Int, height: Int) {
+        Log.d(TAG, "Surface texture size changed: ${width}x${height}")
+        if (isMpvInitialized) {
+            MPVLib.setPropertyString("android-surface-size", "${width}x${height}")
+        }
+    }
+
+    override fun onSurfaceTextureDestroyed(surfaceTexture: SurfaceTexture): Boolean {
+        Log.d(TAG, "Surface texture destroyed")
+        appContext.currentActivity?.let { activity ->
+            (activity as? LifecycleOwner)?.lifecycle?.removeObserver(lifecycleObserver)
+        }
+        if (isMpvInitialized) {
+            MPVLib.removeObserver(this)
+            MPVLib.detachSurface()
+            MPVLib.destroy()
+            isMpvInitialized = false
+        }
+        surface?.release()
+        surface = null
+        return true
+    }
+
+    override fun onSurfaceTextureUpdated(surfaceTexture: SurfaceTexture) {
+        // Called when the SurfaceTexture is updated via updateTexImage()
+    }
+
+    private fun initOptions() {
+        MPVLib.setOptionString("profile", "fast")
+        
+        // GPU rendering mode (gpu or gpu-next)
+        MPVLib.setOptionString("vo", gpuMode)
+        MPVLib.setOptionString("gpu-context", "android")
+        MPVLib.setOptionString("opengl-es", "yes")
+        
+        // Decoder mode mapping
+        val hwdecValue = when (decoderMode) {
+            "auto" -> "auto-copy"
+            "sw" -> "no"
+            "hw" -> "mediacodec-copy"
+            "hw+" -> "mediacodec"
+            else -> "auto-copy"
+        }
+        Log.d(TAG, "Decoder mode: $decoderMode, hwdec value: $hwdecValue, GPU mode: $gpuMode")
+        MPVLib.setOptionString("hwdec", hwdecValue)
+        
+        MPVLib.setOptionString("target-colorspace-hint", "yes")
+        
+        // HDR and Dolby Vision support
+        MPVLib.setOptionString("target-prim", "auto")
+        MPVLib.setOptionString("target-trc", "auto")
+        MPVLib.setOptionString("tone-mapping", "auto")
+        MPVLib.setOptionString("hdr-compute-peak", "auto")
+        MPVLib.setOptionString("vd-lavc-o", "strict=-2")
+        
+        // Workaround for https://github.com/mpv-player/mpv/issues/14651
+        MPVLib.setOptionString("vd-lavc-film-grain", "cpu")
+        
+        MPVLib.setOptionString("ao", "audiotrack,opensles")
+        
+        // Limit demuxer cache based on Android version
+        val cacheMegs = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O_MR1) 64 else 32
+        MPVLib.setOptionString("demuxer-max-bytes", "${cacheMegs * 1024 * 1024}")
+        MPVLib.setOptionString("demuxer-max-back-bytes", "${cacheMegs * 1024 * 1024}")
+        MPVLib.setOptionString("cache", "yes")
+        MPVLib.setOptionString("cache-secs", "30")
+        
+        MPVLib.setOptionString("network-timeout", "60")
+        MPVLib.setOptionString("ytdl", "no")
+        
+        applyHttpHeadersAsOptions()
+        
+        MPVLib.setOptionString("tls-verify", "no")
+        MPVLib.setOptionString("http-reconnect", "yes")
+        MPVLib.setOptionString("stream-reconnect", "yes")
+        
+        MPVLib.setOptionString("demuxer-lavf-o", "live_start_index=0,prefer_x_start=1,http_persistent=0")
+        MPVLib.setOptionString("demuxer-seekable-cache", "yes")
+        MPVLib.setOptionString("force-seekable", "yes")
+        
+        MPVLib.setOptionString("sub-auto", "fuzzy")
+        MPVLib.setOptionString("sub-visibility", "yes")
+        MPVLib.setOptionString("sub-font-size", "48")
+        MPVLib.setOptionString("sub-pos", "100")
+        MPVLib.setOptionString("sub-color", "#FFFFFFFF")
+        MPVLib.setOptionString("sub-border-size", "3")
+        MPVLib.setOptionString("sub-border-color", "#FF000000")
+        MPVLib.setOptionString("sub-shadow-offset", "2")
+        MPVLib.setOptionString("sub-shadow-color", "#80000000")
+        
+        MPVLib.setOptionString("osd-fonts-dir", "/system/fonts")
+        MPVLib.setOptionString("sub-fonts-dir", "/system/fonts")
+        MPVLib.setOptionString("sub-font", "Roboto")
+        MPVLib.setOptionString("embeddedfonts", "yes")
+        
+        MPVLib.setOptionString("sub-codepage", "auto")
+        
+        MPVLib.setOptionString("blend-subtitles", "no")
+        MPVLib.setOptionString("sub-use-margins", "yes")
+        MPVLib.setOptionString("sub-ass-override", "force")
+        MPVLib.setOptionString("sub-scale", "1.0")
+        MPVLib.setOptionString("sub-fix-timing", "yes")
+        
+        MPVLib.setOptionString("osc", "no")
+        MPVLib.setOptionString("osd-level", "1")
+        
+        MPVLib.setOptionString("sid", "auto")
+        
+        MPVLib.setOptionString("terminal", "no")
+        MPVLib.setOptionString("input-default-bindings", "no")
+    }
+
+    private fun observeProperties() {
+        val MPV_FORMAT_NONE = 0
+        val MPV_FORMAT_FLAG = 3
+        val MPV_FORMAT_INT64 = 4
+        val MPV_FORMAT_DOUBLE = 5
+        
+        MPVLib.observeProperty("time-pos", MPV_FORMAT_DOUBLE)
+        MPVLib.observeProperty("duration/full", MPV_FORMAT_DOUBLE)
+        MPVLib.observeProperty("pause", MPV_FORMAT_FLAG)
+        MPVLib.observeProperty("paused-for-cache", MPV_FORMAT_FLAG)
+        MPVLib.observeProperty("eof-reached", MPV_FORMAT_FLAG)
+        MPVLib.observeProperty("video-params/aspect", MPV_FORMAT_DOUBLE)
+        MPVLib.observeProperty("width", MPV_FORMAT_INT64)
+        MPVLib.observeProperty("height", MPV_FORMAT_INT64)
+        MPVLib.observeProperty("track-list", MPV_FORMAT_NONE)
+        
+        MPVLib.observeProperty("sid", MPV_FORMAT_INT64)
+        MPVLib.observeProperty("sub-visibility", MPV_FORMAT_FLAG)
+        MPVLib.observeProperty("sub-text", MPV_FORMAT_NONE)
+    }
+
+    private fun loadFile(url: String) {
+        Log.d(TAG, "Loading file: $url")
+        hasLoadEventFired = false
+        MPVLib.command(arrayOf("loadfile", url))
+    }
+
+    // Public API
+
+    fun setDataSource(url: String) {
+        if (isMpvInitialized) {
+            loadFile(url)
+        } else {
+            pendingDataSource = url
+        }
+    }
+
+    fun setHeaders(headers: Map<String, String>?) {
+        httpHeaders = headers
+        Log.d(TAG, "Headers set: $headers")
+    }
+
+    private fun applyHttpHeadersAsOptions() {
+        val userAgent = httpHeaders?.get("User-Agent") 
+            ?: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        
+        Log.d(TAG, "Setting User-Agent: $userAgent")
+        MPVLib.setOptionString("user-agent", userAgent)
+        
+        httpHeaders?.let { headers ->
+            val otherHeaders = headers.filterKeys { it != "User-Agent" }
+            if (otherHeaders.isNotEmpty()) {
+                val headerString = otherHeaders.map { (key, value) -> "$key: $value" }.joinToString(",")
+                Log.d(TAG, "Setting additional headers: $headerString")
+                MPVLib.setOptionString("http-header-fields", headerString)
+            }
+        }
+    }
+
+    fun setPaused(paused: Boolean) {
+        isPaused = paused
+        if (isMpvInitialized) {
+            MPVLib.setPropertyBoolean("pause", paused)
+        }
+    }
+
+    fun seekTo(positionSeconds: Double) {
+        Log.d(TAG, "seekTo called: positionSeconds=$positionSeconds, isMpvInitialized=$isMpvInitialized")
+        if (isMpvInitialized) {
+            Log.d(TAG, "Executing MPV seek command: seek $positionSeconds absolute")
+            MPVLib.command(arrayOf("seek", positionSeconds.toString(), "absolute"))
+        }
+    }
+
+    fun setSpeed(speed: Double) {
+        if (isMpvInitialized) {
+            MPVLib.setPropertyDouble("speed", speed)
+        }
+    }
+
+    fun setVolume(volume: Double) {
+        if (isMpvInitialized) {
+            MPVLib.setPropertyDouble("volume", volume * 100.0)
+        }
+    }
+
+    fun setAudioTrack(trackId: Int) {
+        if (isMpvInitialized) {
+            if (trackId == -1) {
+                MPVLib.setPropertyString("aid", "no")
+            } else {
+                MPVLib.setPropertyInt("aid", trackId)
+            }
+        }
+    }
+
+    fun setSubtitleTrack(trackId: Int) {
+        Log.d(TAG, "setSubtitleTrack called: trackId=$trackId, isMpvInitialized=$isMpvInitialized")
+        if (isMpvInitialized) {
+            if (trackId == -1) {
+                Log.d(TAG, "Disabling subtitles (sid=no)")
+                MPVLib.setPropertyString("sid", "no")
+                MPVLib.setPropertyString("sub-visibility", "no")
+            } else {
+                Log.d(TAG, "Setting subtitle track to: $trackId")
+                MPVLib.setPropertyInt("sid", trackId)
+                MPVLib.setPropertyString("sub-visibility", "yes")
+                
+                val currentSid = MPVLib.getPropertyInt("sid")
+                val subVisibility = MPVLib.getPropertyString("sub-visibility")
+                val subDelay = MPVLib.getPropertyDouble("sub-delay")
+                val subScale = MPVLib.getPropertyDouble("sub-scale")
+                Log.d(TAG, "After setting - sid=$currentSid, sub-visibility=$subVisibility, sub-delay=$subDelay, sub-scale=$subScale")
+            }
+        }
+    }
+
+    fun setResizeMode(mode: String) {
+        Log.d(TAG, "setResizeMode called: mode=$mode, isMpvInitialized=$isMpvInitialized")
+        if (isMpvInitialized) {
+            when (mode) {
+                "contain" -> {
+                    MPVLib.setPropertyDouble("panscan", 0.0)
+                    MPVLib.setPropertyString("keepaspect", "yes")
+                }
+                "cover" -> {
+                    MPVLib.setPropertyDouble("panscan", 1.0)
+                    MPVLib.setPropertyString("keepaspect", "yes")
+                }
+                "stretch" -> {
+                    MPVLib.setPropertyDouble("panscan", 0.0)
+                    MPVLib.setPropertyString("keepaspect", "no")
+                }
+                else -> {
+                    MPVLib.setPropertyDouble("panscan", 0.0)
+                    MPVLib.setPropertyString("keepaspect", "yes")
+                }
+            }
+        }
+    }
+
+    // Subtitle Styling Methods
+    
+    fun setSubtitleSize(size: Int) {
+        if (isMpvInitialized) {
+            Log.d(TAG, "Setting subtitle size: $size")
+            MPVLib.setPropertyInt("sub-font-size", size)
+        }
+    }
+
+    fun setSubtitleColor(color: String) {
+        if (isMpvInitialized) {
+            val mpvColor = if (color.length == 7) "#FF${color.substring(1)}" else color
+            Log.d(TAG, "Setting subtitle color: $mpvColor")
+            MPVLib.setPropertyString("sub-color", mpvColor)
+        }
+    }
+
+    fun setSubtitleBackgroundColor(color: String, opacity: Float) {
+        if (isMpvInitialized) {
+            val alphaHex = (opacity * 255).toInt().coerceIn(0, 255).let { 
+                String.format("%02X", it) 
+            }
+            val baseColor = if (color.startsWith("#")) color.substring(1) else color
+            val mpvColor = "#${alphaHex}${baseColor.takeLast(6)}"
+            Log.d(TAG, "Setting subtitle background: $mpvColor (opacity: $opacity)")
+            MPVLib.setPropertyString("sub-back-color", mpvColor)
+        }
+    }
+
+    fun setSubtitleBorderSize(size: Int) {
+        if (isMpvInitialized) {
+            Log.d(TAG, "Setting subtitle border size: $size")
+            MPVLib.setPropertyInt("sub-border-size", size)
+        }
+    }
+
+    fun setSubtitleBorderColor(color: String) {
+        if (isMpvInitialized) {
+            val mpvColor = if (color.length == 7) "#FF${color.substring(1)}" else color
+            Log.d(TAG, "Setting subtitle border color: $mpvColor")
+            MPVLib.setPropertyString("sub-border-color", mpvColor)
+        }
+    }
+
+    fun setSubtitleShadow(enabled: Boolean, offset: Int) {
+        if (isMpvInitialized) {
+            Log.d(TAG, "Setting subtitle shadow: enabled=$enabled, offset=$offset")
+            if (enabled) {
+                MPVLib.setPropertyInt("sub-shadow-offset", offset)
+                MPVLib.setPropertyString("sub-shadow-color", "#80000000")
+            } else {
+                MPVLib.setPropertyInt("sub-shadow-offset", 0)
+            }
+        }
+    }
+
+    fun setSubtitlePosition(pos: Int) {
+        if (isMpvInitialized) {
+            Log.d(TAG, "Setting subtitle position: $pos")
+            MPVLib.setPropertyInt("sub-pos", pos)
+        }
+    }
+
+    fun setSubtitleDelay(delaySec: Double) {
+        if (isMpvInitialized) {
+            Log.d(TAG, "Setting subtitle delay: $delaySec seconds")
+            MPVLib.setPropertyDouble("sub-delay", delaySec)
+        }
+    }
+
+    fun setSubtitleScale(scale: Double) {
+        if (isMpvInitialized) {
+            Log.d(TAG, "Setting subtitle scale: $scale")
+            MPVLib.setPropertyDouble("sub-scale", scale)
+        }
+    }
+
+    fun setSubtitleAlignment(align: String) {
+        if (isMpvInitialized) {
+            val mpvAlign = when (align) {
+                "left" -> "left"
+                "right" -> "right"
+                "center" -> "center"
+                else -> "center"
+            }
+            Log.d(TAG, "Setting subtitle alignment: $mpvAlign")
+            MPVLib.setPropertyString("sub-justify", mpvAlign)
+        }
+    }
+
+    fun setSubtitleBold(bold: Boolean) {
+        if (isMpvInitialized) {
+            Log.d(TAG, "Setting subtitle bold: $bold")
+            MPVLib.setPropertyString("sub-bold", if (bold) "yes" else "no")
+        }
+    }
+
+    fun setSubtitleItalic(italic: Boolean) {
+        if (isMpvInitialized) {
+            Log.d(TAG, "Setting subtitle italic: $italic")
+            MPVLib.setPropertyString("sub-italic", if (italic) "yes" else "no")
+        }
+    }
+
+    // MPVLib.EventObserver implementation
+
+    override fun eventProperty(property: String) {
+        Log.d(TAG, "Property changed: $property")
+        when (property) {
+            "track-list" -> {
+                parseAndSendTracks()
+            }
+        }
+    }
+    
+    private fun parseAndSendTracks() {
+        try {
+            val trackCount = MPVLib.getPropertyInt("track-list/count") ?: 0
+            Log.d(TAG, "Track count: $trackCount")
+            
+            val audioTracks = mutableListOf<Map<String, Any>>()
+            val subtitleTracks = mutableListOf<Map<String, Any>>()
+            
+            for (i in 0 until trackCount) {
+                val type = MPVLib.getPropertyString("track-list/$i/type") ?: continue
+                val id = MPVLib.getPropertyInt("track-list/$i/id") ?: continue
+                val title = MPVLib.getPropertyString("track-list/$i/title") ?: ""
+                val lang = MPVLib.getPropertyString("track-list/$i/lang") ?: ""
+                val codec = MPVLib.getPropertyString("track-list/$i/codec") ?: ""
+                
+                val trackName = when {
+                    title.isNotEmpty() -> title
+                    lang.isNotEmpty() -> lang.uppercase()
+                    else -> "Track $id"
+                }
+                
+                val track = mapOf(
+                    "id" to id,
+                    "name" to trackName,
+                    "language" to lang,
+                    "codec" to codec
+                )
+                
+                when (type) {
+                    "audio" -> {
+                        Log.d(TAG, "Found audio track: $track")
+                        audioTracks.add(track)
+                    }
+                    "sub" -> {
+                        Log.d(TAG, "Found subtitle track: $track")
+                        subtitleTracks.add(track)
+                    }
+                }
+            }
+            
+            Log.d(TAG, "Sending tracks - Audio: ${audioTracks.size}, Subtitles: ${subtitleTracks.size}")
+            onTracksChanged(mapOf(
+                "audioTracks" to audioTracks,
+                "subtitleTracks" to subtitleTracks
+            ))
+        } catch (e: Exception) {
+            Log.e(TAG, "Error parsing tracks", e)
+        }
+    }
+
+    override fun eventProperty(property: String, value: Long) {
+        Log.d(TAG, "Property $property = $value (Long)")
+    }
+
+    override fun eventProperty(property: String, value: Double) {
+        Log.d(TAG, "Property $property = $value (Double)")
+        when (property) {
+            "time-pos" -> {
+                val duration = MPVLib.getPropertyDouble("duration/full") ?: MPVLib.getPropertyDouble("duration") ?: 0.0
+                onProgress(mapOf(
+                    "currentTime" to value,
+                    "duration" to duration
+                ))
+            }
+            "duration/full", "duration" -> {
+                if (!hasLoadEventFired) {
+                    val width = MPVLib.getPropertyInt("width") ?: 0
+                    val height = MPVLib.getPropertyInt("height") ?: 0
+                    if (width > 0 && height > 0 && value > 0) {
+                        hasLoadEventFired = true
+                        Log.d(TAG, "Firing onLoad event: duration=$value, width=$width, height=$height")
+                        onLoad(mapOf(
+                            "duration" to value,
+                            "width" to width,
+                            "height" to height
+                        ))
+                    }
+                }
+            }
+        }
+    }
+
+    override fun eventProperty(property: String, value: Boolean) {
+        Log.d(TAG, "Property $property = $value (Boolean)")
+        when (property) {
+            "eof-reached" -> {
+                if (value) {
+                    onEnd(mapOf<String, Any>())
+                }
+            }
+            "paused-for-cache" -> {
+                onBuffering(mapOf("isBuffering" to value))
+            }
+        }
+    }
+
+    override fun eventProperty(property: String, value: String) {
+        Log.d(TAG, "Property $property = $value (String)")
+    }
+
+    override fun event(eventId: Int) {
+        Log.d(TAG, "Event: $eventId")
+        val MPV_EVENT_FILE_LOADED = 8
+        val MPV_EVENT_END_FILE = 7
+        
+        when (eventId) {
+            MPV_EVENT_FILE_LOADED -> {
+                if (!isPaused) {
+                    MPVLib.setPropertyBoolean("pause", false)
+                }
+            }
+            MPV_EVENT_END_FILE -> {
+                Log.d(TAG, "MPV_EVENT_END_FILE")
+                
+                val duration = MPVLib.getPropertyDouble("duration/full") ?: MPVLib.getPropertyDouble("duration") ?: 0.0
+                val timePos = MPVLib.getPropertyDouble("time-pos") ?: 0.0
+                val eofReached = MPVLib.getPropertyBoolean("eof-reached") ?: false
+                
+                Log.d(TAG, "End stats - Duration: $duration, Time: $timePos, EOF: $eofReached")
+                
+                if (duration < 1.0 && !eofReached) {
+                     val customError = "Unable to play media. Source may be unreachable."
+                     Log.e(TAG, "Playback error detected (heuristic): $customError")
+                     onError(mapOf("error" to customError))
+                } else {
+                    onEnd(mapOf<String, Any>())
+                }
+            }
+        }
+    }
+}

--- a/modules/mpv/android/src/main/java/com/dodora/dodostream/mpv/MpvModule.kt
+++ b/modules/mpv/android/src/main/java/com/dodora/dodostream/mpv/MpvModule.kt
@@ -1,0 +1,113 @@
+ /*
+ * Originally part of: NuvioStreaming - https://github.com/tapframe/NuvioStreaming
+ * Licensed under the GPL-3.0 license.
+ *
+ * Modifications:
+ *  - Adapted for DodoStream by Kombustor, 2026.
+ */
+package com.dodora.dodostream.mpv
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class MpvModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("Mpv")
+
+    // View definition with all props and events
+    View(ExpoMpvView::class) {
+      // Events that the view can send to JavaScript
+      Events(
+        "onLoad",
+        "onProgress", 
+        "onEnd",
+        "onError",
+        "onBuffering",
+        "onTracksChanged"
+      )
+
+      // Props
+      Prop("source") { view: ExpoMpvView, source: String? ->
+        source?.let { view.setDataSource(it) }
+      }
+
+      Prop("paused") { view: ExpoMpvView, paused: Boolean ->
+        view.setPaused(paused)
+      }
+
+      Prop("volume") { view: ExpoMpvView, volume: Double ->
+        view.setVolume(volume)
+      }
+
+      Prop("rate") { view: ExpoMpvView, rate: Double ->
+        view.setSpeed(rate)
+      }
+
+      Prop("resizeMode") { view: ExpoMpvView, resizeMode: String? ->
+        view.setResizeMode(resizeMode ?: "contain")
+      }
+
+      Prop("headers") { view: ExpoMpvView, headers: Map<String, String>? ->
+        view.setHeaders(headers)
+      }
+
+      Prop("decoderMode") { view: ExpoMpvView, decoderMode: String? ->
+        view.decoderMode = decoderMode ?: "auto"
+      }
+
+      Prop("gpuMode") { view: ExpoMpvView, gpuMode: String? ->
+        view.gpuMode = gpuMode ?: "gpu"
+      }
+
+      // Subtitle styling props
+      Prop("subtitleSize") { view: ExpoMpvView, size: Int ->
+        view.setSubtitleSize(size)
+      }
+
+      Prop("subtitleColor") { view: ExpoMpvView, color: String? ->
+        view.setSubtitleColor(color ?: "#FFFFFF")
+      }
+
+      Prop("subtitleBackgroundOpacity") { view: ExpoMpvView, opacity: Float ->
+        view.setSubtitleBackgroundColor("#000000", opacity)
+      }
+
+      Prop("subtitleBorderSize") { view: ExpoMpvView, size: Int ->
+        view.setSubtitleBorderSize(size)
+      }
+
+      Prop("subtitleBorderColor") { view: ExpoMpvView, color: String? ->
+        view.setSubtitleBorderColor(color ?: "#000000")
+      }
+
+      Prop("subtitleShadowEnabled") { view: ExpoMpvView, enabled: Boolean ->
+        view.setSubtitleShadow(enabled, if (enabled) 2 else 0)
+      }
+
+      Prop("subtitlePosition") { view: ExpoMpvView, pos: Int ->
+        view.setSubtitlePosition(pos)
+      }
+
+      Prop("subtitleDelay") { view: ExpoMpvView, delay: Float ->
+        view.setSubtitleDelay(delay.toDouble())
+      }
+
+      Prop("subtitleAlignment") { view: ExpoMpvView, align: String? ->
+        view.setSubtitleAlignment(align ?: "center")
+      }
+
+      // Functions that can be called from JavaScript
+      AsyncFunction("seek") { view: ExpoMpvView, position: Double ->
+        view.seekTo(position)
+      }
+
+      AsyncFunction("setAudioTrack") { view: ExpoMpvView, trackId: Int ->
+        view.setAudioTrack(trackId)
+      }
+
+      AsyncFunction("setSubtitleTrack") { view: ExpoMpvView, trackId: Int ->
+        view.setSubtitleTrack(trackId)
+      }
+    }
+  }
+}

--- a/modules/mpv/expo-module.config.json
+++ b/modules/mpv/expo-module.config.json
@@ -1,0 +1,10 @@
+{
+  "platforms": [
+    "android"
+  ],
+  "android": {
+    "modules": [
+      "com.dodora.dodostream.mpv.MpvModule"
+    ]
+  }
+}

--- a/modules/mpv/index.ts
+++ b/modules/mpv/index.ts
@@ -1,0 +1,3 @@
+// Reexport the native view and types
+export { default as MpvView } from './src/MpvView';
+export * from './src/Mpv.types';

--- a/modules/mpv/src/Mpv.types.ts
+++ b/modules/mpv/src/Mpv.types.ts
@@ -1,0 +1,78 @@
+import type { StyleProp, ViewStyle } from 'react-native';
+
+// Event payloads
+export type MpvLoadEventPayload = {
+  duration: number;
+  width: number;
+  height: number;
+};
+
+export type MpvProgressEventPayload = {
+  currentTime: number;
+  duration: number;
+};
+
+export type MpvErrorEventPayload = {
+  error: string;
+};
+
+export type MpvBufferingEventPayload = {
+  isBuffering: boolean;
+};
+
+export type MpvTrack = {
+  id: number;
+  name: string;
+  language: string;
+  codec: string;
+};
+
+export type MpvTracksChangedEventPayload = {
+  audioTracks: MpvTrack[];
+  subtitleTracks: MpvTrack[];
+};
+
+// View props
+export type MpvViewProps = {
+  // Source
+  source: string;
+  paused: boolean;
+
+  // Playback
+  volume?: number;
+  rate?: number;
+  resizeMode?: 'contain' | 'cover' | 'stretch';
+  headers?: Record<string, string>;
+
+  // Decoder settings
+  decoderMode?: 'auto' | 'sw' | 'hw' | 'hw+';
+  gpuMode?: 'gpu' | 'gpu-next';
+
+  // Subtitle styling
+  subtitleSize?: number;
+  subtitleColor?: string;
+  subtitleBackgroundOpacity?: number;
+  subtitleBorderSize?: number;
+  subtitleBorderColor?: string;
+  subtitleShadowEnabled?: boolean;
+  subtitlePosition?: number;
+  subtitleDelay?: number;
+  subtitleAlignment?: 'left' | 'center' | 'right';
+
+  // Events
+  onLoad?: (event: { nativeEvent: MpvLoadEventPayload }) => void;
+  onProgress?: (event: { nativeEvent: MpvProgressEventPayload }) => void;
+  onEnd?: () => void;
+  onError?: (event: { nativeEvent: MpvErrorEventPayload }) => void;
+  onBuffering?: (event: { nativeEvent: MpvBufferingEventPayload }) => void;
+  onTracksChanged?: (event: { nativeEvent: MpvTracksChangedEventPayload }) => void;
+
+  style?: StyleProp<ViewStyle>;
+};
+
+// Ref methods
+export type MpvViewRef = {
+  seek: (position: number) => Promise<void>;
+  setAudioTrack: (trackId: number) => Promise<void>;
+  setSubtitleTrack: (trackId: number) => Promise<void>;
+};

--- a/modules/mpv/src/MpvModule.ts
+++ b/modules/mpv/src/MpvModule.ts
@@ -1,0 +1,3 @@
+// The Mpv module is primarily a view-based module.
+// The native module is auto-loaded by Expo when using requireNativeView('Mpv').
+// No additional module exports needed for the current implementation.

--- a/modules/mpv/src/MpvView.tsx
+++ b/modules/mpv/src/MpvView.tsx
@@ -1,0 +1,34 @@
+import { requireNativeView } from 'expo';
+import * as React from 'react';
+
+import { MpvViewProps, MpvViewRef } from './Mpv.types';
+
+const NativeView: React.ComponentType<MpvViewProps & { ref: any }> = requireNativeView('Mpv');
+export default React.forwardRef<MpvViewRef, MpvViewProps>((props, ref) => {
+  const nativeRef = React.useRef<any>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    seek: async (position: number) => {
+      if (nativeRef.current) {
+        // Expo modules expose functions directly on the native ref
+        return nativeRef.current.seek?.(position);
+      }
+    },
+    setAudioTrack: async (trackId: number) => {
+      if (nativeRef.current) {
+        return nativeRef.current.setAudioTrack?.(trackId);
+      }
+    },
+    setSubtitleTrack: async (trackId: number) => {
+      if (nativeRef.current) {
+        return nativeRef.current.setSubtitleTrack?.(trackId);
+      }
+    },
+  }));
+
+  if (!NativeView) {
+    return null;
+  }
+
+  return <NativeView ref={nativeRef} {...props} />;
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dodostream",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "GPL-3.0-only",
   "main": "expo-router/entry",
   "scripts": {
@@ -48,7 +48,7 @@
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
     "expo-keep-awake": "~15.0.8",
-    "expo-libvlc-player": "^2.2.6",
+    "expo-libvlc-player": "^2.3.1",
     "expo-linear-gradient": "~15.0.8",
     "expo-linking": "~8.0.11",
     "expo-localization": "~17.0.8",
@@ -79,6 +79,7 @@
     "@sentry/cli": "^3.0.3",
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.14",
+    "@types/node": "^25.0.9",
     "@types/react": "~19.1.10",
     "@types/stremio-addon-sdk": "^1.6.12",
     "babel-preset-expo": "~54.0.9",
@@ -89,6 +90,7 @@
     "jest-expo": "^54.0.16",
     "prettier": "^3.2.5",
     "react-test-renderer": "19.1.0",
+    "tsx": "^4.21.0",
     "typescript": "~5.9.2"
   },
   "expo": {

--- a/plugins/withReactNativeTVOSPnpmFix.ts
+++ b/plugins/withReactNativeTVOSPnpmFix.ts
@@ -1,7 +1,7 @@
-const { withDangerousMod } = require('@expo/config-plugins');
-const fs = require('fs');
-const path = require('path');
-const { execSync } = require('child_process');
+import { execSync } from 'child_process';
+import { ConfigPlugin, withDangerousMod } from 'expo/config-plugins';
+import fs from 'fs';
+import path from 'path';
 
 /**
  * Expo config plugin to fix React Native TVOS with pnpm compatibility issues
@@ -10,7 +10,7 @@ const { execSync } = require('child_process');
  * 1. Modifies the Podfile to set REACT_NATIVE_NODE_MODULES_DIR before any requires
  * 2. Creates a symlink from react-native to react-native-tvos in pnpm's node_modules
  */
-const withReactNativeTVOSPnpmFix = (config) => {
+const withReactNativeTVOSPnpmFix: ConfigPlugin = (config) => {
     return withDangerousMod(config, [
         'ios',
         async (config) => {
@@ -80,7 +80,7 @@ ENV['REACT_NATIVE_PATH'] = react_native_path
                     }
                 }
             } catch (error) {
-                console.warn('⚠️  Could not create react-native symlink:', error.message);
+                console.warn('⚠️  Could not create react-native symlink:', error);
                 console.warn('   The build may fail. Try running: pnpm run postinstall');
             }
 
@@ -89,4 +89,4 @@ ENV['REACT_NATIVE_PATH'] = react_native_path
     ]);
 };
 
-module.exports = withReactNativeTVOSPnpmFix;
+export default withReactNativeTVOSPnpmFix;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,8 +80,8 @@ importers:
         specifier: ~15.0.8
         version: 15.0.8(expo@54.0.31)(react@19.1.0)
       expo-libvlc-player:
-        specifier: ^2.2.6
-        version: 2.2.6(expo@54.0.31)(react-native-tvos@0.81.5-1)(react@19.1.0)
+        specifier: ^2.3.1
+        version: 2.3.1(expo@54.0.31)(react-native-tvos@0.81.5-1)(react@19.1.0)
       expo-linear-gradient:
         specifier: ~15.0.8
         version: 15.0.8(expo@54.0.31)(react-native-tvos@0.81.5-1)(react@19.1.0)
@@ -93,7 +93,7 @@ importers:
         version: 17.0.8(expo@54.0.31)(react@19.1.0)
       expo-router:
         specifier: ~6.0.21
-        version: 6.0.21(c31dbd0ecf554e26cdf1a8ae42edc417)
+        version: 6.0.21(126583609e807be24d330ab9e5a1870b)
       expo-splash-screen:
         specifier: ~31.0.13
         version: 31.0.13(expo@54.0.31)
@@ -163,10 +163,13 @@ importers:
         version: 3.0.3
       '@testing-library/react-native':
         specifier: ^13.3.3
-        version: 13.3.3(jest@29.7.0(@types/node@25.0.0))(react-native-tvos@0.81.5-1)(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 13.3.3(jest@29.7.0(@types/node@25.0.9))(react-native-tvos@0.81.5-1)(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
+      '@types/node':
+        specifier: ^25.0.9
+        version: 25.0.9
       '@types/react':
         specifier: ~19.1.10
         version: 19.1.17
@@ -187,16 +190,19 @@ importers:
         version: 10.1.8(eslint@9.39.1(jiti@1.21.7))
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.0.0)
+        version: 29.7.0(@types/node@25.0.9)
       jest-expo:
         specifier: ^54.0.16
-        version: 54.0.16(@babel/core@7.28.5)(expo@54.0.31)(jest@29.7.0(@types/node@25.0.0))(react-native-tvos@0.81.5-1)(react@19.1.0)
+        version: 54.0.16(@babel/core@7.28.5)(expo@54.0.31)(jest@29.7.0(@types/node@25.0.9))(react-native-tvos@0.81.5-1)(react@19.1.0)
       prettier:
         specifier: ^3.2.5
         version: 3.7.4
       react-test-renderer:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ~5.9.2
         version: 5.9.3
@@ -735,6 +741,162 @@ packages:
 
   '@emotion/memoize@0.7.4':
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
+
+  '@esbuild/aix-ppc64@0.27.2':
+    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.2':
+    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.2':
+    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.2':
+    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.2':
+    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.2':
+    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.2':
+    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.2':
+    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.2':
+    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.2':
+    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.2':
+    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.2':
+    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.2':
+    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.2':
+    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.2':
+    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.2':
+    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.2':
+    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.2':
+    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.2':
+    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.2':
+    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.2':
+    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.2':
+    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.2':
+    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.2':
+    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.0':
     resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
@@ -1695,8 +1857,8 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
-  '@types/node@25.0.0':
-    resolution: {integrity: sha512-rl78HwuZlaDIUSeUKkmogkhebA+8K1Hy7tddZuJ3D0xV8pZSfsYGTsliGUol1JPzu9EKnTxPC4L1fiWouStRew==}
+  '@types/node@25.0.9':
+    resolution: {integrity: sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==}
 
   '@types/react@19.1.17':
     resolution: {integrity: sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==}
@@ -2584,6 +2746,11 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.27.2:
+    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -2845,8 +3012,8 @@ packages:
       expo: '*'
       react: '*'
 
-  expo-libvlc-player@2.2.6:
-    resolution: {integrity: sha512-7t0gcKHkZC6Ybzcmc/9Lf9/6sZRZs9vBOf6arewRcQ8swmj2TZw9S/vcDapzTu0EZCiphiDCawOtKehqeVtZHA==}
+  expo-libvlc-player@2.3.1:
+    resolution: {integrity: sha512-x3OTky4sg/FVy3J4cL3Ab3eyBb+90tg1pCsrLkYwZsjC2jYHu51fjWJos59Qe1MCDKqENYrbWVkBTX7M3QS0BQ==}
     peerDependencies:
       expo: '*'
       react: '*'
@@ -4999,6 +5166,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -5998,6 +6170,84 @@ snapshots:
   '@emotion/memoize@0.7.4':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm@0.27.2':
+    optional: true
+
+  '@esbuild/android-x64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.2':
+    optional: true
+
   '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1(jiti@1.21.7))':
     dependencies:
       eslint: 9.39.1(jiti@1.21.7)
@@ -6115,7 +6365,7 @@ snapshots:
       wrap-ansi: 7.0.0
       ws: 8.18.3
     optionalDependencies:
-      expo-router: 6.0.21(c31dbd0ecf554e26cdf1a8ae42edc417)
+      expo-router: 6.0.21(126583609e807be24d330ab9e5a1870b)
       react-native: react-native-tvos@0.81.5-1(patch_hash=e91fec82df6b5870c3625e79ba3c16e25c5cecceb339f6f21cd184eca5d363df)(@babel/core@7.28.5)(@types/react@19.1.17)(react-native-tvos@0.81.5-1)(react@19.1.0)
     transitivePeerDependencies:
       - bufferutil
@@ -6402,7 +6652,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -6415,14 +6665,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@25.0.0)
+      jest-config: 29.7.0(@types/node@25.0.9)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -6453,7 +6703,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -6471,7 +6721,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -6495,7 +6745,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit: 0.1.2
@@ -6569,7 +6819,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -7235,7 +7485,7 @@ snapshots:
       '@tanstack/query-core': 5.90.12
       react: 19.1.0
 
-  '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@25.0.0))(react-native-tvos@0.81.5-1)(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@25.0.9))(react-native-tvos@0.81.5-1)(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       jest-matcher-utils: 30.2.0
       picocolors: 1.1.1
@@ -7245,7 +7495,7 @@ snapshots:
       react-test-renderer: 19.1.0(react@19.1.0)
       redent: 3.0.0
     optionalDependencies:
-      jest: 29.7.0(@types/node@25.0.0)
+      jest: 29.7.0(@types/node@25.0.9)
 
   '@tootallnate/once@2.0.0': {}
 
@@ -7279,7 +7529,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
 
   '@types/hammerjs@2.0.46': {}
 
@@ -7300,7 +7550,7 @@ snapshots:
 
   '@types/jsdom@20.0.1':
     dependencies:
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
@@ -7308,7 +7558,7 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
-  '@types/node@25.0.0':
+  '@types/node@25.0.9':
     dependencies:
       undici-types: 7.16.0
 
@@ -7902,7 +8152,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -7911,7 +8161,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -8022,13 +8272,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  create-jest@29.7.0(@types/node@25.0.0):
+  create-jest@29.7.0(@types/node@25.0.9):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.0.0)
+      jest-config: 29.7.0(@types/node@25.0.9)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -8326,6 +8576,35 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.27.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.2
+      '@esbuild/android-arm': 0.27.2
+      '@esbuild/android-arm64': 0.27.2
+      '@esbuild/android-x64': 0.27.2
+      '@esbuild/darwin-arm64': 0.27.2
+      '@esbuild/darwin-x64': 0.27.2
+      '@esbuild/freebsd-arm64': 0.27.2
+      '@esbuild/freebsd-x64': 0.27.2
+      '@esbuild/linux-arm': 0.27.2
+      '@esbuild/linux-arm64': 0.27.2
+      '@esbuild/linux-ia32': 0.27.2
+      '@esbuild/linux-loong64': 0.27.2
+      '@esbuild/linux-mips64el': 0.27.2
+      '@esbuild/linux-ppc64': 0.27.2
+      '@esbuild/linux-riscv64': 0.27.2
+      '@esbuild/linux-s390x': 0.27.2
+      '@esbuild/linux-x64': 0.27.2
+      '@esbuild/netbsd-arm64': 0.27.2
+      '@esbuild/netbsd-x64': 0.27.2
+      '@esbuild/openbsd-arm64': 0.27.2
+      '@esbuild/openbsd-x64': 0.27.2
+      '@esbuild/openharmony-arm64': 0.27.2
+      '@esbuild/sunos-x64': 0.27.2
+      '@esbuild/win32-arm64': 0.27.2
+      '@esbuild/win32-ia32': 0.27.2
+      '@esbuild/win32-x64': 0.27.2
 
   escalade@3.2.0: {}
 
@@ -8664,7 +8943,7 @@ snapshots:
       expo: 54.0.31(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.21)(react-native-tvos@0.81.5-1)(react@19.1.0)
       react: 19.1.0
 
-  expo-libvlc-player@2.2.6(expo@54.0.31)(react-native-tvos@0.81.5-1)(react@19.1.0):
+  expo-libvlc-player@2.3.1(expo@54.0.31)(react-native-tvos@0.81.5-1)(react@19.1.0):
     dependencies:
       expo: 54.0.31(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.21)(react-native-tvos@0.81.5-1)(react@19.1.0)
       react: 19.1.0
@@ -8714,7 +8993,7 @@ snapshots:
       react: 19.1.0
       react-native: react-native-tvos@0.81.5-1(patch_hash=e91fec82df6b5870c3625e79ba3c16e25c5cecceb339f6f21cd184eca5d363df)(@babel/core@7.28.5)(@types/react@19.1.17)(react-native-tvos@0.81.5-1)(react@19.1.0)
 
-  expo-router@6.0.21(c31dbd0ecf554e26cdf1a8ae42edc417):
+  expo-router@6.0.21(126583609e807be24d330ab9e5a1870b):
     dependencies:
       '@expo/metro-runtime': 6.1.2(expo@54.0.31)(react-dom@19.1.0(react@19.1.0))(react-native-tvos@0.81.5-1)(react@19.1.0)
       '@expo/schema-utils': 0.1.8
@@ -8748,7 +9027,7 @@ snapshots:
       vaul: 1.1.2(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     optionalDependencies:
       '@react-navigation/drawer': 7.7.9(@react-navigation/native@7.1.25(react-native-tvos@0.81.5-1)(react@19.1.0))(react-native-gesture-handler@2.28.0(react-native-tvos@0.81.5-1)(react@19.1.0))(react-native-reanimated@4.1.6(@babel/core@7.28.5)(react-native-tvos@0.81.5-1)(react-native-worklets@0.5.1(@babel/core@7.28.5)(react-native-tvos@0.81.5-1)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native-tvos@0.81.5-1)(react@19.1.0))(react-native-screens@4.16.0(react-native-tvos@0.81.5-1)(react@19.1.0))(react-native-tvos@0.81.5-1)(react@19.1.0)
-      '@testing-library/react-native': 13.3.3(jest@29.7.0(@types/node@25.0.0))(react-native-tvos@0.81.5-1)(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
+      '@testing-library/react-native': 13.3.3(jest@29.7.0(@types/node@25.0.9))(react-native-tvos@0.81.5-1)(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
       react-dom: 19.1.0(react@19.1.0)
       react-native-gesture-handler: 2.28.0(react-native-tvos@0.81.5-1)(react@19.1.0)
       react-native-reanimated: 4.1.6(@babel/core@7.28.5)(react-native-tvos@0.81.5-1)(react-native-worklets@0.5.1(@babel/core@7.28.5)(react-native-tvos@0.81.5-1)(react@19.1.0))(react@19.1.0)
@@ -9400,7 +9679,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.1
@@ -9420,16 +9699,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@25.0.0):
+  jest-cli@29.7.0(@types/node@25.0.9):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.0.0)
+      create-jest: 29.7.0(@types/node@25.0.9)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.0.0)
+      jest-config: 29.7.0(@types/node@25.0.9)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -9439,7 +9718,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@25.0.0):
+  jest-config@29.7.0(@types/node@25.0.9):
     dependencies:
       '@babel/core': 7.28.5
       '@jest/test-sequencer': 29.7.0
@@ -9464,7 +9743,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -9501,7 +9780,7 @@ snapshots:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -9515,11 +9794,11 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-expo@54.0.16(@babel/core@7.28.5)(expo@54.0.31)(jest@29.7.0(@types/node@25.0.0))(react-native-tvos@0.81.5-1)(react@19.1.0):
+  jest-expo@54.0.16(@babel/core@7.28.5)(expo@54.0.31)(jest@29.7.0(@types/node@25.0.9))(react-native-tvos@0.81.5-1)(react@19.1.0):
     dependencies:
       '@expo/config': 12.0.12
       '@expo/json-file': 10.0.8
@@ -9530,7 +9809,7 @@ snapshots:
       jest-environment-jsdom: 29.7.0
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
-      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@25.0.0))
+      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@25.0.9))
       json5: 2.2.3
       lodash: 4.17.21
       react-native: react-native-tvos@0.81.5-1(patch_hash=e91fec82df6b5870c3625e79ba3c16e25c5cecceb339f6f21cd184eca5d363df)(@babel/core@7.28.5)(@types/react@19.1.17)(react-native-tvos@0.81.5-1)(react@19.1.0)
@@ -9552,7 +9831,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -9598,7 +9877,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -9633,7 +9912,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -9661,7 +9940,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.3
@@ -9707,7 +9986,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -9728,11 +10007,11 @@ snapshots:
       chalk: 3.0.0
       prompts: 2.4.2
 
-  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@25.0.0)):
+  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@25.0.9)):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 4.1.2
-      jest: 29.7.0(@types/node@25.0.0)
+      jest: 29.7.0(@types/node@25.0.9)
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -9743,7 +10022,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -9752,17 +10031,17 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 25.0.0
+      '@types/node': 25.0.9
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@25.0.0):
+  jest@29.7.0(@types/node@25.0.9):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.0.0)
+      jest-cli: 29.7.0(@types/node@25.0.9)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -11288,6 +11567,13 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.2
+      get-tsconfig: 4.13.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:

--- a/src/components/settings/AboutSettingsContent.tsx
+++ b/src/components/settings/AboutSettingsContent.tsx
@@ -166,7 +166,7 @@ export const AboutSettingsContent: FC = memo(() => {
     if (tapCountRef.current >= DEVELOPER_TAP_COUNT) {
       tapCountRef.current = 0;
       debug('developerModeActivated');
-      router.push('/(tabs)/settings/developer');
+      router.push('/(app)/(tabs)/settings/developer');
     }
   }, [debug, router]);
 

--- a/src/components/settings/PlaybackSettingsContent.tsx
+++ b/src/components/settings/PlaybackSettingsContent.tsx
@@ -98,7 +98,9 @@ export const PlaybackSettingsContent: FC<PlaybackSettingsContentProps> = memo(
                   gap="s"
                   minWidth={140}>
                   <Ionicons name="play" size={20} color={theme.colors.textSecondary} />
-                  <Text variant="body">{player === 'exoplayer' ? 'ExoPlayer' : 'VLC'}</Text>
+                  <Text variant="body">
+                    {PLAYER_PICKER_ITEMS.find((item) => item.value === player)?.label || 'Unknown'}
+                  </Text>
                   <Ionicons name="chevron-down" size={20} color={theme.colors.textSecondary} />
                 </Box>
               </TouchableOpacity>

--- a/src/components/video/MPVPlayer.tsx
+++ b/src/components/video/MPVPlayer.tsx
@@ -1,0 +1,188 @@
+/**
+ * MPV Player React Native Component
+ * Based on NuvioStreaming's implementation (GPL-3.0 license)
+ * https://github.com/tapframe/NuvioStreaming
+ */
+import React, { forwardRef, useImperativeHandle, useRef, useCallback, useState, memo } from 'react';
+import { View, StyleSheet, Platform } from 'react-native';
+import { MpvView, MpvViewRef } from 'modules/mpv';
+import { PlayerRef, AudioTrack, TextTrack, PlayerProps } from '@/types/player';
+import { useDebugLogger } from '@/utils/debug';
+
+export const MPVPlayer = memo(
+  forwardRef<PlayerRef, PlayerProps>(
+    (
+      {
+        source,
+        paused,
+        onProgress,
+        onLoad,
+        onBuffer,
+        onEnd,
+        onError,
+        onAudioTracks,
+        onTextTracks,
+        selectedAudioTrack,
+        selectedTextTrack,
+        fitMode = 'contain',
+      },
+      ref
+    ) => {
+      const debug = useDebugLogger('MPVPlayer');
+      const nativeRef = useRef<MpvViewRef>(null);
+      const [isReady, setIsReady] = useState(false);
+      const isReadyRef = useRef(false);
+      const lastAudioTrackRef = useRef<number | undefined>(undefined);
+      const lastSubtitleTrackRef = useRef<number | undefined>(undefined);
+
+      useImperativeHandle(
+        ref,
+        () => ({
+          seekTo: async (time: number, _duration: number) => {
+            if (!isReadyRef.current) {
+              debug('seekToAborted', { time, reason: 'not-ready' });
+              return;
+            }
+            debug('seekTo', { time });
+            await nativeRef.current?.seek(time);
+          },
+        }),
+        [debug]
+      );
+
+      // Handle audio track changes
+      React.useEffect(() => {
+        if (!isReady || selectedAudioTrack === undefined) return;
+        const trackId = selectedAudioTrack?.index ?? -1;
+        if (trackId !== lastAudioTrackRef.current) {
+          lastAudioTrackRef.current = trackId;
+          debug('setAudioTrack', { trackId });
+          nativeRef.current?.setAudioTrack(trackId);
+        }
+      }, [debug, isReady, selectedAudioTrack]);
+
+      // Handle subtitle track changes
+      React.useEffect(() => {
+        if (!isReady) return;
+        // Only set video-source subtitles (addon subtitles are handled by CustomSubtitles)
+        const trackId =
+          selectedTextTrack?.source === 'video'
+            ? (selectedTextTrack?.playerIndex ?? selectedTextTrack?.index ?? -1)
+            : -1;
+        if (trackId !== lastSubtitleTrackRef.current) {
+          lastSubtitleTrackRef.current = trackId;
+          debug('setSubtitleTrack', { trackId, source: selectedTextTrack?.source });
+          nativeRef.current?.setSubtitleTrack(trackId);
+        }
+      }, [debug, isReady, selectedTextTrack]);
+
+      const handleLoad = useCallback(
+        (event: { nativeEvent: { duration: number; width: number; height: number } }) => {
+          debug('load', { duration: event.nativeEvent.duration });
+          isReadyRef.current = true;
+          setIsReady(true);
+          onLoad?.({ duration: event.nativeEvent.duration });
+        },
+        [debug, onLoad]
+      );
+
+      const handleProgress = useCallback(
+        (event: { nativeEvent: { currentTime: number; duration: number } }) => {
+          onProgress?.({
+            currentTime: event.nativeEvent.currentTime,
+            duration: event.nativeEvent.duration,
+          });
+        },
+        [onProgress]
+      );
+
+      const handleEnd = useCallback(() => {
+        debug('end');
+        onEnd?.();
+      }, [debug, onEnd]);
+
+      const handleError = useCallback(
+        (event: { nativeEvent: { error: string } }) => {
+          debug('error', { error: event.nativeEvent.error });
+          onError?.(event.nativeEvent.error || 'MPV playback error');
+        },
+        [debug, onError]
+      );
+
+      const handleBuffering = useCallback(
+        (event: { nativeEvent: { isBuffering: boolean } }) => {
+          debug('buffering', { isBuffering: event.nativeEvent.isBuffering });
+          onBuffer?.(event.nativeEvent.isBuffering);
+        },
+        [debug, onBuffer]
+      );
+
+      const handleTracksChanged = useCallback(
+        (event: {
+          nativeEvent: {
+            audioTracks: { id: number; name: string; language: string }[];
+            subtitleTracks: { id: number; name: string; language: string }[];
+          };
+        }) => {
+          const { audioTracks, subtitleTracks } = event.nativeEvent;
+          debug('tracksChanged', {
+            audioCount: audioTracks?.length,
+            subtitleCount: subtitleTracks?.length,
+          });
+
+          // Process audio tracks
+          if (audioTracks) {
+            const processedAudioTracks: AudioTrack[] = audioTracks.map((track) => ({
+              index: track.id,
+              title: track.name || `Audio ${track.id}`,
+              language: track.language,
+            }));
+            onAudioTracks?.(processedAudioTracks);
+          }
+
+          // Process subtitle tracks (in-stream video subtitles)
+          if (subtitleTracks) {
+            const processedTextTracks: TextTrack[] = subtitleTracks.map((track) => ({
+              source: 'video' as const,
+              index: track.id,
+              title: track.name || `Subtitle ${track.id}`,
+              language: track.language,
+              playerIndex: track.id,
+            }));
+            onTextTracks?.(processedTextTracks);
+          }
+        },
+        [debug, onAudioTracks, onTextTracks]
+      );
+
+      // Fallback for non-Android platforms
+      if (Platform.OS !== 'android') {
+        return <View style={[styles.player, { backgroundColor: 'black' }]} />;
+      }
+
+      return (
+        <MpvView
+          ref={nativeRef}
+          style={styles.player}
+          source={source}
+          paused={paused}
+          resizeMode={fitMode}
+          onLoad={handleLoad}
+          onProgress={handleProgress}
+          onEnd={handleEnd}
+          onError={handleError}
+          onBuffering={handleBuffering}
+          onTracksChanged={handleTracksChanged}
+        />
+      );
+    }
+  )
+);
+
+MPVPlayer.displayName = 'MPVPlayer';
+
+const styles = StyleSheet.create({
+  player: {
+    flex: 1,
+  },
+});

--- a/src/constants/playback.ts
+++ b/src/constants/playback.ts
@@ -1,5 +1,6 @@
 import { PickerItem } from '@/components/basic/PickerModal';
 import type { PlayerType } from '@/types/player';
+import { Platform } from 'react-native';
 
 // Playback ratios
 // Used across watch-history, continue-watching, and autoplay decisions.
@@ -21,7 +22,15 @@ export const PLAYER_CONTROLS_AUTO_HIDE_MS = 5000;
 export const SKIP_FORWARD_SECONDS = 15;
 export const SKIP_BACKWARD_SECONDS = 15;
 
-export const PLAYER_PICKER_ITEMS: PickerItem<PlayerType>[] = [
+// All available players (MPV is Android-only)
+const ALL_PLAYER_PICKER_ITEMS: PickerItem<PlayerType>[] = [
   { label: 'ExoPlayer', value: 'exoplayer' },
+  { label: 'MPV (Experimental)', value: 'mpv' },
   { label: 'VLC', value: 'vlc' },
 ];
+
+// Filtered player items based on platform (MPV only on Android)
+export const PLAYER_PICKER_ITEMS: PickerItem<PlayerType>[] =
+  Platform.OS === 'android'
+    ? ALL_PLAYER_PICKER_ITEMS
+    : ALL_PLAYER_PICKER_ITEMS.filter((item) => item.value !== 'mpv');

--- a/src/types/player.ts
+++ b/src/types/player.ts
@@ -1,4 +1,4 @@
-export type PlayerType = 'vlc' | 'exoplayer';
+export type PlayerType = 'vlc' | 'exoplayer' | 'mpv';
 
 export type TextTrackSource = 'video' | 'addon';
 

--- a/src/utils/__tests__/player-errors.test.ts
+++ b/src/utils/__tests__/player-errors.test.ts
@@ -1,0 +1,97 @@
+import { classifyPlayerError } from '../player-errors';
+
+describe('classifyPlayerError', () => {
+    describe('codec errors', () => {
+        it('should identify ExoPlayer decoding errors', () => {
+            const error =
+                'ERROR_CODE_DECODING_FAILED ExoPlaybackException: MediaCodecVideoRenderer error';
+            const result = classifyPlayerError(error);
+
+            expect(result.type).toBe('codec');
+            expect(result.shouldFallback).toBe(true);
+            expect(result.userMessage).toBe('Video format not supported by this player');
+        });
+
+        it('should identify Dolby Vision codec issues', () => {
+            const error =
+                '24003 ExoPlaybackException: MediaCodecVideoRenderer error, index=0, format=Format(1, null, null, video/dolby-vision, hev1.08.06, -1, und, [3840, 1606, -1.0, null], [-1, -1]), format_supported=NO_EXCEEDS_CAPABILITIES';
+            const result = classifyPlayerError(error);
+
+            expect(result.type).toBe('codec');
+            expect(result.shouldFallback).toBe(true);
+        });
+
+        it('should identify MediaCodec decoder failures', () => {
+            const error = 'MediaCodecVideoDecoderException: Decoder failed: c2.android.hevc.decoder';
+            const result = classifyPlayerError(error);
+
+            expect(result.type).toBe('codec');
+            expect(result.shouldFallback).toBe(true);
+        });
+
+        it('should identify codec exception errors', () => {
+            const error = 'android.media.MediaCodec$CodecException: Error 0xe';
+            const result = classifyPlayerError(error);
+
+            expect(result.type).toBe('codec');
+            expect(result.shouldFallback).toBe(true);
+        });
+    });
+
+    describe('network errors', () => {
+        it('should identify network timeout errors', () => {
+            const error = 'ERROR_CODE_TIMEOUT Connection timeout';
+            const result = classifyPlayerError(error);
+
+            expect(result.type).toBe('network');
+            expect(result.shouldFallback).toBe(false);
+            expect(result.userMessage).toBe('Network error - check your connection');
+        });
+
+        it('should identify connection failed errors', () => {
+            const error = 'ERROR_CODE_IO Connection failed';
+            const result = classifyPlayerError(error);
+
+            expect(result.type).toBe('network');
+            expect(result.shouldFallback).toBe(false);
+        });
+
+        it('should identify HTTP errors as network errors', () => {
+            const error = 'HTTP Error: Unable to connect';
+            const result = classifyPlayerError(error);
+
+            expect(result.type).toBe('network');
+            expect(result.shouldFallback).toBe(false);
+        });
+    });
+
+    describe('source errors', () => {
+        it('should identify 404 errors', () => {
+            const error = 'ERROR_CODE_CONTENT_NOT_FOUND 404 Not Found';
+            const result = classifyPlayerError(error);
+
+            expect(result.type).toBe('source');
+            expect(result.shouldFallback).toBe(false);
+            expect(result.userMessage).toBe('Stream unavailable or expired');
+        });
+
+        it('should identify forbidden errors', () => {
+            const error = '403 Forbidden';
+            const result = classifyPlayerError(error);
+
+            expect(result.type).toBe('source');
+            expect(result.shouldFallback).toBe(false);
+        });
+    });
+
+    describe('unknown errors', () => {
+        it('should default to unknown with fallback enabled', () => {
+            const error = 'Something weird happened';
+            const result = classifyPlayerError(error);
+
+            expect(result.type).toBe('unknown');
+            expect(result.shouldFallback).toBe(true);
+            expect(result.userMessage).toBe('Playback error occurred');
+        });
+    });
+});

--- a/src/utils/player-errors.ts
+++ b/src/utils/player-errors.ts
@@ -1,0 +1,104 @@
+/**
+ * Player error classification utilities.
+ * Used to determine appropriate error handling and fallback behavior.
+ */
+
+export type PlayerErrorType = 'codec' | 'network' | 'source' | 'unknown';
+
+export interface PlayerErrorClassification {
+    type: PlayerErrorType;
+    shouldFallback: boolean;
+    userMessage: string;
+}
+
+/**
+ * Classifies a player error message to determine the appropriate handling strategy.
+ * 
+ * Codec/Decoding errors should trigger fallback to alternate players.
+ * Network errors should NOT trigger fallback (user can retry or select different stream).
+ * 
+ * @param errorMessage - The error message from the player (typically from composeErrorString)
+ * @returns Classification containing error type, fallback recommendation, and user-friendly message
+ */
+export function classifyPlayerError(errorMessage: string): PlayerErrorClassification {
+    const lowerMessage = errorMessage.toLowerCase();
+
+    // Codec/Decoding errors - SHOULD fallback
+    // These indicate the player cannot decode the video format
+    const codecIndicators = [
+        'error_code_decoding_failed',
+        'mediacodecvideorenderer error',
+        'decoder failed',
+        'codec exception',
+        'format_supported=no',
+        'no_exceeds_capabilities',
+        'mediacodecvideodecoderexception',
+        'error 0xe', // Android MediaCodec error code for codec failure
+        'video/dolby-vision', // Dolby Vision not supported
+        'hevc', // HEVC/H.265 codec issues
+        'av1', // AV1 codec issues
+    ];
+
+    if (codecIndicators.some((indicator) => lowerMessage.includes(indicator))) {
+        return {
+            type: 'codec',
+            shouldFallback: true,
+            userMessage: 'Video format not supported by this player',
+        };
+    }
+
+    // Network errors - should NOT fallback
+    // These indicate connectivity issues that won't be resolved by changing players
+    const networkIndicators = [
+        'error_code_io',
+        'error_code_timeout',
+        'error_code_connection',
+        'network',
+        'timeout',
+        'connection refused',
+        'connection failed',
+        'unable to connect',
+        'no internet',
+        'http error',
+        'failed to fetch',
+        'unreachable',
+    ];
+
+    if (networkIndicators.some((indicator) => lowerMessage.includes(indicator))) {
+        return {
+            type: 'network',
+            shouldFallback: false,
+            userMessage: 'Network error - check your connection',
+        };
+    }
+
+    // Source errors - should NOT fallback
+    // These indicate the stream itself is broken/unavailable
+    const sourceIndicators = [
+        'bad_http_status',
+        'error_code_behind_live_window',
+        'error_code_content_not_found',
+        '404',
+        '403',
+        '500',
+        'not found',
+        'forbidden',
+        'unauthorized',
+    ];
+
+    if (sourceIndicators.some((indicator) => lowerMessage.includes(indicator))) {
+        return {
+            type: 'source',
+            shouldFallback: false,
+            userMessage: 'Stream unavailable or expired',
+        };
+    }
+
+    // Unknown errors - cautiously allow fallback
+    // If we can't classify the error, it's safer to try fallback
+    return {
+        type: 'unknown',
+        shouldFallback: true,
+        userMessage: 'Playback error occurred',
+    };
+}

--- a/test-output.txt
+++ b/test-output.txt
@@ -1,0 +1,240 @@
+
+> dodostream@0.3.0 test /Users/fabian/Projects/dodostream
+> jest
+
+watchman warning:  Recrawled this watch 19 times, most recently because:
+MustScanSubDirs UserDroppedTo resolve, please review the information on
+https://facebook.github.io/watchman/docs/troubleshooting.html#recrawl
+To clear this warning, run:
+`watchman watch-del '/Users/fabian/Projects/dodostream' ; watchman watch-project '/Users/fabian/Projects/dodostream'`
+
+FAIL src/utils/__tests__/version.test.ts
+  ● Test suite failed to run
+
+    Cannot find module 'modules/mpv' from 'jest.setup.js'
+
+      61 |
+      62 |     const MpvView = React.forwardRef((props, ref) => {
+    > 63 |         React.useImperativeHandle(ref, () => ({
+         |               ^
+      64 |             seek: jest.fn(),
+      65 |             setVolume: jest.fn(),
+      66 |             setRate: jest.fn(),
+
+      at Resolver._throwModNotFoundError (node_modules/.pnpm/jest-resolve@29.7.0/node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (jest.setup.js:63:15)
+
+FAIL src/hooks/__tests__/useContinueWatching.test.ts
+  ● Test suite failed to run
+
+    Cannot find module 'modules/mpv' from 'jest.setup.js'
+
+      61 |
+      62 |     const MpvView = React.forwardRef((props, ref) => {
+    > 63 |         React.useImperativeHandle(ref, () => ({
+         |               ^
+      64 |             seek: jest.fn(),
+      65 |             setVolume: jest.fn(),
+      66 |             setRate: jest.fn(),
+
+      at Resolver._throwModNotFoundError (node_modules/.pnpm/jest-resolve@29.7.0/node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (jest.setup.js:63:15)
+
+FAIL src/store/__tests__/watch-history.store.test.ts
+  ● Test suite failed to run
+
+    Cannot find module 'modules/mpv' from 'jest.setup.js'
+
+      61 |
+      62 |     const MpvView = React.forwardRef((props, ref) => {
+    > 63 |         React.useImperativeHandle(ref, () => ({
+         |               ^
+      64 |             seek: jest.fn(),
+      65 |             setVolume: jest.fn(),
+      66 |             setRate: jest.fn(),
+
+      at Resolver._throwModNotFoundError (node_modules/.pnpm/jest-resolve@29.7.0/node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (jest.setup.js:63:15)
+
+FAIL src/components/video/__tests__/VideoPlayer.test.tsx
+  ● Test suite failed to run
+
+    Cannot find module 'modules/mpv' from 'jest.setup.js'
+
+      61 |
+      62 |     const MpvView = React.forwardRef((props, ref) => {
+    > 63 |         React.useImperativeHandle(ref, () => ({
+         |               ^
+      64 |             seek: jest.fn(),
+      65 |             setVolume: jest.fn(),
+      66 |             setRate: jest.fn(),
+
+      at Resolver._throwModNotFoundError (node_modules/.pnpm/jest-resolve@29.7.0/node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (jest.setup.js:63:15)
+
+FAIL src/components/media/__tests__/ContinueWatchingCard.test.tsx
+  ● Test suite failed to run
+
+    Cannot find module 'modules/mpv' from 'jest.setup.js'
+
+      61 |
+      62 |     const MpvView = React.forwardRef((props, ref) => {
+    > 63 |         React.useImperativeHandle(ref, () => ({
+         |               ^
+      64 |             seek: jest.fn(),
+      65 |             setVolume: jest.fn(),
+      66 |             setRate: jest.fn(),
+
+      at Resolver._throwModNotFoundError (node_modules/.pnpm/jest-resolve@29.7.0/node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (jest.setup.js:63:15)
+
+FAIL src/utils/__tests__/subtitles.test.ts
+  ● Test suite failed to run
+
+    Cannot find module 'modules/mpv' from 'jest.setup.js'
+
+      61 |
+      62 |     const MpvView = React.forwardRef((props, ref) => {
+    > 63 |         React.useImperativeHandle(ref, () => ({
+         |               ^
+      64 |             seek: jest.fn(),
+      65 |             setVolume: jest.fn(),
+      66 |             setRate: jest.fn(),
+
+      at Resolver._throwModNotFoundError (node_modules/.pnpm/jest-resolve@29.7.0/node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (jest.setup.js:63:15)
+
+FAIL src/utils/__tests__/format.test.ts
+  ● Test suite failed to run
+
+    Cannot find module 'modules/mpv' from 'jest.setup.js'
+
+      61 |
+      62 |     const MpvView = React.forwardRef((props, ref) => {
+    > 63 |         React.useImperativeHandle(ref, () => ({
+         |               ^
+      64 |             seek: jest.fn(),
+      65 |             setVolume: jest.fn(),
+      66 |             setRate: jest.fn(),
+
+      at Resolver._throwModNotFoundError (node_modules/.pnpm/jest-resolve@29.7.0/node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (jest.setup.js:63:15)
+
+FAIL src/api/stremio/__tests__/hooks.test.ts
+  ● Test suite failed to run
+
+    Cannot find module 'modules/mpv' from 'jest.setup.js'
+
+      61 |
+      62 |     const MpvView = React.forwardRef((props, ref) => {
+    > 63 |         React.useImperativeHandle(ref, () => ({
+         |               ^
+      64 |             seek: jest.fn(),
+      65 |             setVolume: jest.fn(),
+      66 |             setRate: jest.fn(),
+
+      at Resolver._throwModNotFoundError (node_modules/.pnpm/jest-resolve@29.7.0/node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (jest.setup.js:63:15)
+
+FAIL src/hooks/__tests__/useAutoPlay.test.ts
+  ● Test suite failed to run
+
+    Cannot find module 'modules/mpv' from 'jest.setup.js'
+
+      61 |
+      62 |     const MpvView = React.forwardRef((props, ref) => {
+    > 63 |         React.useImperativeHandle(ref, () => ({
+         |               ^
+      64 |             seek: jest.fn(),
+      65 |             setVolume: jest.fn(),
+      66 |             setRate: jest.fn(),
+
+      at Resolver._throwModNotFoundError (node_modules/.pnpm/jest-resolve@29.7.0/node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (jest.setup.js:63:15)
+
+FAIL src/hooks/__tests__/useMediaNavigation.test.ts
+  ● Test suite failed to run
+
+    Cannot find module 'modules/mpv' from 'jest.setup.js'
+
+      61 |
+      62 |     const MpvView = React.forwardRef((props, ref) => {
+    > 63 |         React.useImperativeHandle(ref, () => ({
+         |               ^
+      64 |             seek: jest.fn(),
+      65 |             setVolume: jest.fn(),
+      66 |             setRate: jest.fn(),
+
+      at Resolver._throwModNotFoundError (node_modules/.pnpm/jest-resolve@29.7.0/node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (jest.setup.js:63:15)
+
+FAIL src/components/media/__tests__/MediaCard.test.tsx
+  ● Test suite failed to run
+
+    Cannot find module 'modules/mpv' from 'jest.setup.js'
+
+      61 |
+      62 |     const MpvView = React.forwardRef((props, ref) => {
+    > 63 |         React.useImperativeHandle(ref, () => ({
+         |               ^
+      64 |             seek: jest.fn(),
+      65 |             setVolume: jest.fn(),
+      66 |             setRate: jest.fn(),
+
+      at Resolver._throwModNotFoundError (node_modules/.pnpm/jest-resolve@29.7.0/node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (jest.setup.js:63:15)
+
+FAIL src/components/video/__tests__/VideoPlayerSession.test.tsx
+  ● Test suite failed to run
+
+    Cannot find module 'modules/mpv' from 'jest.setup.js'
+
+      61 |
+      62 |     const MpvView = React.forwardRef((props, ref) => {
+    > 63 |         React.useImperativeHandle(ref, () => ({
+         |               ^
+      64 |             seek: jest.fn(),
+      65 |             setVolume: jest.fn(),
+      66 |             setRate: jest.fn(),
+
+      at Resolver._throwModNotFoundError (node_modules/.pnpm/jest-resolve@29.7.0/node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (jest.setup.js:63:15)
+
+FAIL src/components/video/__tests__/PlayerControls.test.tsx
+  ● Test suite failed to run
+
+    Cannot find module 'modules/mpv' from 'jest.setup.js'
+
+      61 |
+      62 |     const MpvView = React.forwardRef((props, ref) => {
+    > 63 |         React.useImperativeHandle(ref, () => ({
+         |               ^
+      64 |             seek: jest.fn(),
+      65 |             setVolume: jest.fn(),
+      66 |             setRate: jest.fn(),
+
+      at Resolver._throwModNotFoundError (node_modules/.pnpm/jest-resolve@29.7.0/node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (jest.setup.js:63:15)
+
+FAIL src/utils/__tests__/player-errors.test.ts
+  ● Test suite failed to run
+
+    Cannot find module 'modules/mpv' from 'jest.setup.js'
+
+      61 |
+      62 |     const MpvView = React.forwardRef((props, ref) => {
+    > 63 |         React.useImperativeHandle(ref, () => ({
+         |               ^
+      64 |             seek: jest.fn(),
+      65 |             setVolume: jest.fn(),
+      66 |             setRate: jest.fn(),
+
+      at Resolver._throwModNotFoundError (node_modules/.pnpm/jest-resolve@29.7.0/node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (jest.setup.js:63:15)
+
+Test Suites: 14 failed, 14 total
+Tests:       0 total
+Snapshots:   0 total
+Time:        0.633 s
+Ran all test suites.
+ ELIFECYCLE  Test failed. See above for more details.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "**/*.tsx",
     ".expo/types/**/*.ts",
     "expo-env.d.ts"
-  ]
+  ],
 }


### PR DESCRIPTION
## Summary

Adds MPV player as a third alternative player, only for Android (TV).

## Motivation

Lack of VLC tone mapping and some dolby vision profile support.