### PR TITLE
WIP: Strip debug logs in production builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 EXPO_NO_TELEMETRY=true
 EXPO_PUBLIC_GITHUB_RELEASES_URL=https://github.com/DodoraApp/DodoStream/releases
 NODE_ENV=development
+
+# Strip debug logger calls in production builds (defaults to true if not set)
+# Set to 'false' to keep debug logs in production builds
+STRIP_DEBUG_LOGS=true

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,6 +4,16 @@ module.exports = function (api) {
 
   plugins.push('react-native-worklets/plugin');
 
+  // Strip debug calls in production builds
+  // For Expo: use caller.dev to detect production mode (when --dev false is used)
+  const stripDebugLogs = process.env.STRIP_DEBUG_LOGS !== 'false';
+  const isProduction = process.env.NODE_ENV === 'production';
+
+  if (isProduction && stripDebugLogs) {
+    console.log("Babel: Stripping debug calls from production build");
+    plugins.push('./plugins/babel-plugin-strip-debug-calls.js');
+  }
+
   return {
     presets: ['babel-preset-expo'],
     plugins,

--- a/eas.json
+++ b/eas.json
@@ -37,7 +37,8 @@
       "environment": "production",
       "channel": "production",
       "env": {
-        "APP_VARIANT": "prod"
+        "APP_VARIANT": "prod",
+        "STRIP_DEBUG_LOGS": "true"
       },
       "autoIncrement": true
     },

--- a/plugins/babel-plugin-strip-debug-calls.js
+++ b/plugins/babel-plugin-strip-debug-calls.js
@@ -1,0 +1,103 @@
+/**
+ * Babel plugin to strip debug logger calls in production builds
+ * 
+ * This plugin safely removes:
+ * - Imports from '@/utils/debug'
+ * - Variables initialized with useDebugLogger() or createDebugLogger()
+ * - All calls to those debug logger variables (regardless of variable name)
+ * 
+ * Uses proper scope tracking and binding management to avoid removing unrelated code.
+ */
+module.exports = function ({ types: t }) {
+    return {
+        name: 'strip-debug-calls',
+        visitor: {
+            Program: {
+                exit(path, state) {
+                    // Collect debug logger bindings
+                    const debugLoggerBindings = new Set();
+                    const debugImportNames = new Set();
+
+                    // Find all imports from @/utils/debug
+                    path.traverse({
+                        ImportDeclaration(importPath) {
+                            const source = importPath.node.source.value;
+                            if (source !== '@/utils/debug') return;
+
+                            // Track imported function names
+                            importPath.node.specifiers.forEach(specifier => {
+                                if (t.isImportSpecifier(specifier) || t.isImportDefaultSpecifier(specifier)) {
+                                    debugImportNames.add(specifier.local.name);
+                                }
+                            });
+                        }
+                    });
+
+                    // Find all variable declarations that use the imported debug functions
+                    path.traverse({
+                        VariableDeclarator(declaratorPath) {
+                            const init = declaratorPath.node.init;
+                            const id = declaratorPath.node.id;
+
+                            if (!init || !t.isIdentifier(id)) return;
+
+                            // Check if it's a call to useDebugLogger or createDebugLogger
+                            if (
+                                t.isCallExpression(init) &&
+                                t.isIdentifier(init.callee) &&
+                                debugImportNames.has(init.callee.name)
+                            ) {
+                                // Get the binding for this debug logger variable
+                                const binding = declaratorPath.scope.getBinding(id.name);
+                                if (binding) {
+                                    debugLoggerBindings.add(binding);
+                                }
+                            }
+                        }
+                    });
+
+                    // Remove all references to debug loggers (calls to them)
+                    debugLoggerBindings.forEach(binding => {
+                        binding.referencePaths.forEach(refPath => {
+                            // Only remove if it's being called
+                            const parent = refPath.parent;
+                            if (t.isCallExpression(parent) && parent.callee === refPath.node) {
+                                const statement = refPath.getStatementParent();
+                                if (statement) {
+                                    statement.remove();
+                                }
+                            }
+                        });
+                    });
+
+                    // Remove the variable declarations for debug loggers
+                    debugLoggerBindings.forEach(binding => {
+                        const declarator = binding.path;
+                        if (declarator && t.isVariableDeclarator(declarator.node)) {
+                            const declaration = declarator.parentPath;
+                            if (
+                                declaration &&
+                                t.isVariableDeclaration(declaration.node) &&
+                                declaration.node.declarations.length === 1
+                            ) {
+                                declaration.remove();
+                            } else {
+                                declarator.remove();
+                            }
+                        }
+                    });
+
+                    // Remove imports from @/utils/debug
+                    path.traverse({
+                        ImportDeclaration(importPath) {
+                            const source = importPath.node.source.value;
+                            if (source === '@/utils/debug') {
+                                importPath.remove();
+                            }
+                        }
+                    });
+                },
+            },
+        },
+    };
+};


### PR DESCRIPTION
## Summary

What does this change do?

## Motivation

Why is this change needed?

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] Tested on: Android TV / Android / tvOS (specify)

## Screenshots / Video (if UI)

Attach if relevant.
