### PR TITLE
feat: improve landscape UI for tablets and phones

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -93,7 +93,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
             tsconfigPaths: true,
             reactCompiler: true
         },
-        orientation: 'portrait',
+        orientation: 'default',
         icon: './assets/app/icon.png',
         backgroundColor: appBackgroundColor,
         userInterfaceStyle: 'dark',

--- a/plugins/withAndroidConfigChanges.ts
+++ b/plugins/withAndroidConfigChanges.ts
@@ -5,9 +5,9 @@ import { ConfigPlugin, AndroidConfig, withAndroidManifest } from 'expo/config-pl
  * 
  * This prevents the activity from being recreated when certain configuration changes occur,
  * which fixes the "linking configured in multiple places" error with expo-router
- * and prevents app reloads when video display modes change.
+ * and prevents app reloads when video display modes or orientation change.
  * 
- * Adds: smallestScreenSize, density
+ * Adds: smallestScreenSize, density, orientation, screenSize
  */
 const withAndroidConfigChanges: ConfigPlugin = (config) => {
     return withAndroidManifest(config, (config) => {
@@ -17,7 +17,7 @@ const withAndroidConfigChanges: ConfigPlugin = (config) => {
         const existingConfigChanges = mainActivity.$?.['android:configChanges']?.split('|') || [];
 
         // Add our required config changes if not already present
-        const requiredChanges = ['smallestScreenSize', 'density'];
+        const requiredChanges = ['smallestScreenSize', 'density', 'orientation', 'screenSize'];
         const newConfigChanges = [...new Set([...existingConfigChanges, ...requiredChanges])];
 
         // Update the activity with the new configChanges

--- a/src/app/(app)/(tabs)/_layout.tsx
+++ b/src/app/(app)/(tabs)/_layout.tsx
@@ -5,13 +5,18 @@ import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ResponsiveLayout } from '@/components/layout/ResponsiveLayout';
 import { NAV_ITEMS } from '@/constants/navigation';
+import { useWindowDimensions } from 'react-native';
 
 export default function TabsLayout() {
   const { bottom } = useSafeAreaInsets();
   const breakpoint = useBreakpoint();
+  const { width, height } = useWindowDimensions();
+  const isLandscape = width > height;
 
-  // Hide tabs on tablet/TV since we have sidebar
+  // Hide tabs on tablet/TV since we have sidebar,
+  // and collapse to a compact style on phones in landscape to save vertical space
   const showTabs = breakpoint === 'mobile';
+  const compactTabs = showTabs && isLandscape;
 
   return (
     <ResponsiveLayout>
@@ -23,9 +28,9 @@ export default function TabsLayout() {
                 backgroundColor: theme.colors.cardBackground,
                 borderTopColor: theme.colors.cardBorder,
                 borderTopWidth: 1,
-                paddingBottom: bottom,
-                paddingTop: 10,
-                height: 65 + bottom,
+                paddingBottom: compactTabs ? 2 : bottom,
+                paddingTop: compactTabs ? 4 : 10,
+                height: compactTabs ? 46 : 65 + bottom,
               }
             : {
                 display: 'none', // Hide tabs on tablet/TV
@@ -34,8 +39,9 @@ export default function TabsLayout() {
           tabBarInactiveTintColor: theme.colors.textSecondary,
           tabBarLabelStyle: {
             fontFamily: theme.fonts.poppinsSemiBold,
-            fontSize: 12,
+            fontSize: compactTabs ? 10 : 12,
           },
+          tabBarIconStyle: compactTabs ? { marginBottom: -2 } : undefined,
         }}>
         {NAV_ITEMS.map((item) => (
           <Tabs.Screen

--- a/src/components/basic/Container.tsx
+++ b/src/components/basic/Container.tsx
@@ -1,6 +1,7 @@
 import { SafeAreaView, type Edge } from 'react-native-safe-area-context';
+import { useWindowDimensions } from 'react-native';
 import theme, { Box } from '@/theme/theme';
-import { FC, PropsWithChildren } from 'react';
+import { FC, PropsWithChildren, useMemo } from 'react';
 
 interface ContainerProps {
   disablePadding?: boolean;
@@ -12,9 +13,27 @@ export const Container: FC<PropsWithChildren<ContainerProps>> = ({
   disablePadding,
   safeAreaEdges,
 }) => {
+  const { width, height } = useWindowDimensions();
+  const isLandscape = width > height;
+
+  // In landscape, always include left and right safe area edges
+  // to account for notches, punch-holes, and rounded corners
+  const edges = useMemo<Edge[] | undefined>(() => {
+    if (!safeAreaEdges) {
+      if (isLandscape) return ['left', 'right'];
+      return undefined;
+    }
+    if (!isLandscape) return safeAreaEdges;
+
+    const edgeSet = new Set(safeAreaEdges);
+    edgeSet.add('left');
+    edgeSet.add('right');
+    return Array.from(edgeSet) as Edge[];
+  }, [safeAreaEdges, isLandscape]);
+
   return (
     <SafeAreaView
-      edges={safeAreaEdges}
+      edges={edges}
       style={{ flex: 1, backgroundColor: theme.colors.mainBackground }}>
       <Box
         flex={1}

--- a/src/components/layout/ResponsiveLayout.tsx
+++ b/src/components/layout/ResponsiveLayout.tsx
@@ -12,12 +12,13 @@ interface ResponsiveLayoutProps {
 
 export const ResponsiveLayout: FC<ResponsiveLayoutProps> = ({ children, maxWidth }) => {
   const breakpoint = useBreakpoint();
-  const { width } = useWindowDimensions();
+  const { width, height } = useWindowDimensions();
+  const isLandscape = width > height;
 
   // Show sidebar on tablet and TV
   const showSidebar = breakpoint === 'tablet' || breakpoint === 'tv';
 
-  // Calculate max width for content (50% on large screens)
+  // Calculate max width for content
   const contentMaxWidth: number | undefined =
     maxWidth !== undefined
       ? typeof maxWidth === 'number'
@@ -25,7 +26,9 @@ export const ResponsiveLayout: FC<ResponsiveLayoutProps> = ({ children, maxWidth
         : undefined
       : breakpoint === 'tv'
         ? width * 0.5
-        : undefined;
+        : breakpoint === 'tablet' && isLandscape
+          ? Math.min(width * 0.75, 1000)
+          : undefined;
 
   // Handle TV back button to focus sidebar
   const handleBackPress = useCallback(() => {

--- a/src/components/media/HeroSection.tsx
+++ b/src/components/media/HeroSection.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, useWindowDimensions } from 'react-native';
 import { MotiView } from 'moti';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Image } from 'expo-image';
@@ -30,6 +30,11 @@ interface HeroSectionProps {
 export const HeroSection = memo(({ hasTVPreferredFocus = false }: HeroSectionProps) => {
   const theme = useTheme<Theme>();
   const { pushToStreams, navigateToDetails } = useMediaNavigation();
+  const { width, height } = useWindowDimensions();
+  const isLandscape = width > height;
+
+  // In landscape, scale hero height to avoid consuming the entire viewport
+  const heroHeight = isLandscape ? Math.min(HERO_HEIGHT, height * 0.7) : HERO_HEIGHT;
 
   const [activeIndex, setActiveIndex] = useState(0);
   const autoScrollRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -162,7 +167,7 @@ export const HeroSection = memo(({ hasTVPreferredFocus = false }: HeroSectionPro
   }
 
   return (
-    <Box height={HERO_HEIGHT} width="100%" overflow="hidden">
+    <Box height={heroHeight} width="100%" overflow="hidden">
       {/* Background Image with Fade Animation */}
       <MotiView
         key={activeItem.id}

--- a/src/components/media/MediaDetailsHeader.tsx
+++ b/src/components/media/MediaDetailsHeader.tsx
@@ -1,5 +1,5 @@
 import { memo, PropsWithChildren, useMemo } from 'react';
-import { Dimensions } from 'react-native';
+import { useWindowDimensions } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { AnimatedImage } from '@/components/basic/AnimatedImage';
 import { Box, Text } from '@/theme/theme';
@@ -14,8 +14,6 @@ import { MEDIA_DETAILS_HEADER_COVER_HEIGHT } from '@/constants/media';
 import { Tag } from '@/components/basic/Tag';
 import FadeIn from '@/components/basic/FadeIn';
 
-const { width } = Dimensions.get('window');
-
 interface MediaDetailsHeaderProps {
   media: MetaDetail;
   video?: MetaVideo;
@@ -25,6 +23,13 @@ interface MediaDetailsHeaderProps {
 export const MediaDetailsHeader = memo(
   ({ media, video, variant = 'full', children }: PropsWithChildren<MediaDetailsHeaderProps>) => {
     const theme = useTheme<Theme>();
+    const { width, height } = useWindowDimensions();
+    const isLandscape = width > height;
+
+    // Scale cover height in landscape to avoid consuming the whole viewport
+    const coverHeight = isLandscape
+      ? Math.min(MEDIA_DETAILS_HEADER_COVER_HEIGHT, height * 0.5)
+      : MEDIA_DETAILS_HEADER_COVER_HEIGHT;
 
     const coverSource = useMemo(() => {
       return getDetailsCoverSource(media.background, media.poster);
@@ -50,7 +55,7 @@ export const MediaDetailsHeader = memo(
     return (
       <Box>
         {variant !== 'minimal' && (
-          <Box height={MEDIA_DETAILS_HEADER_COVER_HEIGHT} width={width} position="relative">
+          <Box height={coverHeight} width={width} position="relative">
             <AnimatedImage
               source={coverSource}
               style={{ width: '100%', height: '100%' }}


### PR DESCRIPTION
- Unlock device rotation (orientation: 'default' in Expo config)
- Add orientation/screenSize to Android configChanges to prevent activity recreation
- Stabilize breakpoint detection using shorter dimension (min of width/height) so rotating a phone doesn't jump to tablet tier; TV always returns 'tv' via Platform.isTV
- Add isLandscape to useResponsiveLayout and adjust grid columns per orientation
- Scale hero and cover image heights proportionally in landscape
- Add side-by-side details layout (poster left, info right) for landscape phones/tablets
- Compact tab bar on phones in landscape to save vertical space
- Include left/right safe area edges in landscape for notch/punch-hole handling
- Constrain tablet landscape content width in ResponsiveLayout sidebar mode
- Replace static Dimensions.get('window') with reactive useWindowDimensions in MediaDetailsHeader

## Summary

Adds proper landscape support for Android tablets and phones. Previously the app was locked to portrait orientation, so landscape was just the portrait layout stretched

## Testing

- Android Tablet
- Needs testing on TV
